### PR TITLE
chore: prefer `nuxt` over `nuxi`

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "ui:dev": "nuxt dev ui",
     "ui:build": "nuxt build ui",
     "lint": "eslint .",
-    "prepare": "nuxi prepare ui",
+    "prepare": "nuxt prepare ui",
     "vscode:prepublish": "nr build",
     "publish": "vsce publish --no-dependencies",
     "pack": "vsce package --no-dependencies",


### PR DESCRIPTION

this follows up on https://github.com/nuxt/nuxt/pull/32237 to use `nuxt` command consistently now that we no longer need compatibility with nuxt 2.