### PR TITLE
chore: migrate to pnpm v11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
 
     strategy:
       matrix:
-        node: [18]
+        node: [22]
         os: [ubuntu-latest, windows-latest, macos-latest]
       fail-fast: false
 

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,0 @@
-ignore-workspace-root-check=true
-node-linker=hoisted

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "displayName": "ext-slug",
   "version": "0.0.0",
   "private": true,
-  "packageManager": "pnpm@10.21.0",
+  "packageManager": "pnpm@11.1.2",
   "description": "",
   "license": "MIT",
   "homepage": "https://github.com/publisher-slug/ext-slug#readme",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,3 +2,13 @@ packages:
   - playground
   - examples/*
   - ui
+
+allowBuilds:
+  '@vscode/vsce-sign': false
+  esbuild: false
+  keytar: false
+  vue-demi: false
+
+ignoreWorkspaceRootCheck: true
+
+nodeLinker: hoisted


### PR DESCRIPTION
### 📚 Description

this migrates us to pnpm v11, and - in particular - to moving to `allowBuilds`