### PR TITLE
chore: replace `latest` ranges with caret ranges

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,7 +65,7 @@ importers:
   ui:
     dependencies:
       '@nuxt/devtools':
-        specifier: latest
+        specifier: ^4.0.0-alpha.9
         version: 4.0.0-alpha.9(cac@7.0.0)(crossws@0.4.10(srvx@0.11.22))(db0@0.3.4)(devframe@0.7.14(cac@7.0.0)(srvx@0.11.22)(typescript@5.9.3))(ioredis@5.11.1)(magic-string@1.1.0)(oxc-parser@0.140.0)(rolldown@1.2.0)(srvx@0.11.22)(typescript@5.9.3)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.62.3)(vite@8.1.5(@types/node@24.10.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0)))(valibot@1.4.2(typescript@5.9.3))(vite@8.1.5(@types/node@24.10.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))(vue@3.5.40(typescript@5.9.3))
       '@vscode/webview-ui-toolkit':
         specifier: ^1.4.0

--- a/ui/package.json
+++ b/ui/package.json
@@ -9,7 +9,7 @@
     "typecheck": "vue-tsc --noEmit"
   },
   "dependencies": {
-    "@nuxt/devtools": "latest",
+    "@nuxt/devtools": "^4.0.0-alpha.9",
     "@vscode/webview-ui-toolkit": "^1.4.0",
     "nuxt": "^4.0.0"
   },


### PR DESCRIPTION
`latest` is a curse and can easily drift, or change wildly on lockfile regeneration